### PR TITLE
add basic build test

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,8 +14,9 @@ mkdir -p ~/src && cd ~/src
 git clone https://github.com/bitcoin/bitcoin.git
 cd bitcoin
 ./autogen.sh
-./configure --without-gui --without-upnp --disable-tests
+./configure --without-gui --without-upnp
 make
+make check
 make install
 
 echo "> Create Bitcoin User"


### PR DESCRIPTION
Disabling tests for a software like bitcoin is a really bad idea! It can have huge consequences e.g. unclaimable funds in the future.

`make check` should be added before `make install`. It runs all tests needed to verify correct build of binaries. Does not run all unit tests so does not take long to run, but is a must for verification. You would not want your software to flip e.g. the 18th bit of your pubkey just because a muon hit the cpu when it was compiling :) `make check`  handles that!